### PR TITLE
Change Train to Bus on mode of transportation

### DIFF
--- a/client/src/components/RoutePlanner.jsx
+++ b/client/src/components/RoutePlanner.jsx
@@ -171,7 +171,7 @@ const RoutePlanner = ({ mapInstance, setDirectionsResponse }) => {
               checked={travelMode === "TRANSIT"}
               onChange={handleTravelModeChange}
             />
-            Train
+            Bus
           </label>
         </div>
         


### PR DESCRIPTION
Changed the name "Train" to "Bus"
Travel mode "TRANSIT" shows bus routes correctly on the map
It also shows the combination of bus route (solid blue line) + walk route (dotted blue line) 